### PR TITLE
Fix playTween2 completion condition for overshooting easing functions

### DIFF
--- a/src/Animations/Types/Tween.lua
+++ b/src/Animations/Types/Tween.lua
@@ -113,7 +113,7 @@ local function playTween2(tweenInfo: TweenInfo, callback: Callback<number>, comp
 
 				callback(value)
 
-				if value >= 1 then
+				if alpha >= 1 then
 					if tweenRepeatCount ~= 0 and repeats < tweenRepeatCount then
 						repeats += 1
 						elapsed = 0


### PR DESCRIPTION
**Problem**: `playTween2` uses `value >= 1` as completion condition, causing animations with overshooting easing (Elastic, Back) to end prematurely when they first overshoot.

**Solution**: Change completion condition to `alpha >= 1` to complete based on time progress rather than output value.